### PR TITLE
Add TLS option to support secure helm clients

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -euf -o pipefail
 
-PLUGIN_VERSION=${PLUGIN_VERSION:-"0.4.0"}
+PLUGIN_VERSION=${PLUGIN_VERSION:-"0.4.1"}
 
 file="${HELM_PLUGIN_DIR:-"$(helm home)/plugins/helm-update-config"}/bin/helm-update-config"
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "update-config"
-version: "0.4.0"
+version: "0.4.1"
 usage: "update config of a running release"
 description: Update configuration values of a running release.
 ignoreFlags: false


### PR DESCRIPTION
Add a new flag "--tls"  for `update-client` plugin to support IBM Helm clients that only allow secure TLS interactions.